### PR TITLE
docs: fix simple typo, requsted -> requested

### DIFF
--- a/struct/t_set.c
+++ b/struct/t_set.c
@@ -482,7 +482,7 @@ void srandmemberWithCountCommand(redisClient *c) {
      * In this case we create a set from scratch with all the elements, and
      * subtract random elements to reach the requested number of elements.
      *
-     * This is done because if the number of requsted elements is just
+     * This is done because if the number of requested elements is just
      * a bit less than the number of elements in the set, the natural approach
      * used into CASE 3 is highly inefficient. */
     if (count*SRANDMEMBER_SUB_STRATEGY_MUL > size) {


### PR DESCRIPTION
There is a small typo in struct/t_set.c.

Should read `requested` rather than `requsted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md